### PR TITLE
fix: get the pull-request remote url from github

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -149,6 +149,7 @@ func getPullRequest(baseRepository *types.Repository, number int) (*types.PullRe
 		Owner:      pr.Head.Repo.Owner.GetLogin(),
 		BranchName: pr.Head.GetRef(),
 		Number:     number,
+		CloneURL:   pr.Head.Repo.GetSSHURL(),
 	}, nil
 }
 

--- a/types/pullrequest.go
+++ b/types/pullrequest.go
@@ -21,6 +21,7 @@ type PullRequest struct {
 	BranchName string `json:"branch_name,omitempty"`
 	Number     int    `json:"number,omitempty"`
 	Project    string `json:"project,omitempty"`
+	CloneURL   string `json:"clone_url,omitempty"`
 }
 
 const defaultInitialBranch = "master"
@@ -113,8 +114,11 @@ func (pr *PullRequest) Checkout(newBranch bool) error {
 		_, err := git.Remote(remote.GetURL(pr.Owner))
 		if err != nil {
 			// git remote add $remote git@github.com:$remote/$project.git
-			forkURL := fmt.Sprintf("git@github.com:%s/%s.git", pr.Owner, pr.Project)
-			out, errRemote := git.Remote(remote.Add(pr.Owner, forkURL), git.Debug)
+			cloneURL := pr.CloneURL
+			if cloneURL == "" { // backward-compatible with previous configurations
+				cloneURL = fmt.Sprintf("git@github.com:%s/%s.git", pr.Owner, pr.Project)
+			}
+			out, errRemote := git.Remote(remote.Add(pr.Owner, cloneURL), git.Debug)
 			if errRemote != nil {
 				log.Println(out)
 				return errors.Wrapf(errRemote, "[PR %d] unable to add remote", pr.Number)


### PR DESCRIPTION
Instead of guessing the remote url from the pull-request owner and the
project name, let's use the pull-request information to get the owner
repository.

This fixes errors when the pull-request author fork doesn't match the
upstream project name.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>