### PR TITLE
feat: optional git suffix for remote URL.

### DIFF
--- a/types/repository.go
+++ b/types/repository.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/ldez/prm/local"
 )
@@ -14,7 +15,7 @@ type Repository struct {
 }
 
 func newRepository(URL string) (*Repository, error) {
-	exp := regexp.MustCompile(`(?:git@github.com:|https://github.com/)([^/]+)/(.+)\.git`)
+	exp := regexp.MustCompile(`(?:git@github.com:|https://github.com/)([^/]+)/(.+)`)
 
 	if !exp.MatchString(URL) {
 		return nil, fmt.Errorf("invalid URL: %s", URL)
@@ -26,10 +27,8 @@ func newRepository(URL string) (*Repository, error) {
 		return nil, fmt.Errorf("invalid URL: %s", URL)
 	}
 
-	return &Repository{
-		Owner: parts[1],
-		Name:  parts[2],
-	}, nil
+	name := strings.TrimSuffix(strings.TrimSuffix(parts[2], ".git"), "/")
+	return &Repository{Owner: parts[1], Name: name}, nil
 }
 
 // GetRepository get repository information by remote name.

--- a/types/repository_test.go
+++ b/types/repository_test.go
@@ -22,11 +22,35 @@ func TestNewRepository(t *testing.T) {
 			},
 		},
 		{
-			desc: "SSH",
-			url:  "git@github.com:containous/traefik.git",
+			desc: "HTTPS without suffix",
+			url:  "https://github.com/ldez/prm",
 			expected: &Repository{
-				Owner: "containous",
-				Name:  "traefik",
+				Owner: "ldez",
+				Name:  "prm",
+			},
+		},
+		{
+			desc: "HTTPS without suffix ending with /",
+			url:  "https://github.com/ldez/prm/",
+			expected: &Repository{
+				Owner: "ldez",
+				Name:  "prm",
+			},
+		},
+		{
+			desc: "SSH",
+			url:  "git@github.com:ldez/prm.git",
+			expected: &Repository{
+				Owner: "ldez",
+				Name:  "prm",
+			},
+		},
+		{
+			desc: "SSH without suffix",
+			url:  "git@github.com:ldez/prm",
+			expected: &Repository{
+				Owner: "ldez",
+				Name:  "prm",
 			},
 		},
 	}
@@ -37,17 +61,9 @@ func TestNewRepository(t *testing.T) {
 			t.Parallel()
 
 			repository, err := newRepository(test.url)
-
 			require.NoError(t, err)
+
 			assert.Equal(t, test.expected, repository)
 		})
 	}
-}
-
-func TestNewRepository_should_fail_when_invalid_URL(t *testing.T) {
-	url := "https://github.com/ldez/prm"
-
-	_, err := newRepository(url)
-
-	require.Error(t, err)
 }


### PR DESCRIPTION
Before this PR:

| URL                             | Valid |
|---------------------------------|-------|
| https://github.com/ldez/prm     | NO    |
| https://github.com/ldez/prm/    | NO    |
| https://github.com/ldez/prm.git | YES   |
| git@github.com:ldez/prm | NO   |
| git@github.com:ldez/prm.git | YES   |

After this PR:

| URL                             | Valid |
|---------------------------------|-------|
| https://github.com/ldez/prm     | YES   |
| https://github.com/ldez/prm/    | YES   |
| https://github.com/ldez/prm.git | YES   |
| git@github.com:ldez/prm | YES   |
| git@github.com:ldez/prm.git | YES   |


Fixes #6 