### PR TITLE
Fix Transform in GitRemote

### DIFF
--- a/choose/gitremote.go
+++ b/choose/gitremote.go
@@ -32,10 +32,15 @@ func GitRemote(remotes []local.Remote) (string, error) {
 				Options: surveyOpts,
 				Help:    "The remote must be the repository where are the Pull Requests.",
 			},
-			Transform: survey.TransformString(func(value string) string {
-				parts := strings.SplitN(value, "]:", 2)
-				return strings.TrimPrefix(parts[0], "[")
-			}),
+			Transform: func(ans interface{}) interface{} {
+				answer, ok := ans.(survey.OptionAnswer)
+				if !ok {
+					return nil
+				}
+				parts := strings.SplitN(answer.Value, "]:", 2)
+				answer.Value = strings.TrimPrefix(parts[0], "[")
+				return answer
+			},
 		},
 	}
 


### PR DESCRIPTION
The transformer in `GitRemote` was not working correctly.
It's because we have this check in `survey`:
https://github.com/AlecAivazis/survey/blob/e4745b24cd4333f6bfbb5b6d335ed3385e7cf4ee/transform.go#L30-L33
And since `Select` is using an `OptionAnswer` and not a `string`, the transformer was not applied:
https://github.com/AlecAivazis/survey/blob/e4745b24cd4333f6bfbb5b6d335ed3385e7cf4ee/select.go#L315

Fixes #26 (you can reproduce this bug when you initialize prm on a project with already existing remotes).